### PR TITLE
Fix: Respect configured chains from runtime settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The EVM plugin provides comprehensive functionality for interacting with EVM-com
 ## Installation
 
 ```bash
-pnpm install @elizaos/plugin-evm
+bun add @elizaos/plugin-evm
 ```
 
 ## Configuration
@@ -182,19 +182,19 @@ Execute the proposal with ID 1 on the 0xdeadbeef00000000000000000000000000000000
 2. Install dependencies:
 
 ```bash
-pnpm install
+bun install
 ```
 
 3. Build the plugin:
 
 ```bash
-pnpm run build
+bun run build
 ```
 
 4. Run tests:
 
 ```bash
-pnpm test
+bun test
 ```
 
 ## API Reference
@@ -293,7 +293,7 @@ We welcome community feedback and contributions to help prioritize these enhance
 The plugin contains tests. Whether you're using **TDD** or not, please make sure to run the tests before submitting a PR:
 
 ```bash
-pnpm test
+bun test
 ```
 
 Contributions are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-evm",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/providers/wallet.ts
+++ b/src/providers/wallet.ts
@@ -206,8 +206,8 @@ const genChainsFromRuntime = (runtime: IAgentRuntime): Record<string, Chain> => 
 
   // If no chains are configured, default to mainnet and base
   const chainsToUse = configuredChains.length > 0 ? configuredChains : ['mainnet', 'base'];
-  
-  if (configuredChains.length === 0) {
+
+  if (!configuredChains.length) {
     elizaLogger.warn('No EVM chains configured in settings, defaulting to mainnet and base');
   }
 

--- a/src/providers/wallet.ts
+++ b/src/providers/wallet.ts
@@ -36,7 +36,7 @@ import type { SupportedChain } from '../types';
 
 export class WalletProvider {
   private cacheKey = 'evm/wallet';
-  chains: Record<string, Chain> = { ...viemChains };
+  chains: Record<string, Chain> = {};
   account!: PrivateKeyAccount;
   runtime: IAgentRuntime;
   constructor(
@@ -45,7 +45,9 @@ export class WalletProvider {
     chains?: Record<string, Chain>
   ) {
     this.setAccount(accountOrPrivateKey);
-    this.addChains(chains);
+    if (chains) {
+      this.chains = chains;
+    }
     this.runtime = runtime;
   }
 
@@ -159,9 +161,8 @@ export class WalletProvider {
     if (!chains) {
       return;
     }
-    for (const chain of Object.keys(chains)) {
-      this.chains[chain] = chains[chain];
-    }
+    // Only add the chains that are explicitly provided
+    this.chains = { ...this.chains, ...chains };
   };
 
   private createHttpTransport = (chainName: SupportedChain) => {
@@ -200,17 +201,18 @@ export class WalletProvider {
 }
 
 const genChainsFromRuntime = (runtime: IAgentRuntime): Record<string, Chain> => {
-  // Get chains from settings or use default supported chains
+  // Get chains from settings - ONLY use configured chains
   const configuredChains = (runtime?.character?.settings?.chains?.evm as SupportedChain[]) || [];
 
-  // Default chains to include if not specified in settings
-  const defaultChains = ['mainnet', 'polygon', 'arbitrum', 'base', 'optimism', 'linea'];
+  // If no chains are configured, return empty object
+  if (configuredChains.length === 0) {
+    elizaLogger.warn('No EVM chains configured in settings');
+    return {};
+  }
 
-  // Combine configured chains with defaults, removing duplicates
-  const chainNames = [...new Set([...configuredChains, ...defaultChains])];
   const chains: Record<string, Chain> = {};
 
-  for (const chainName of chainNames) {
+  for (const chainName of configuredChains) {
     try {
       // Try to get RPC URL from settings using different formats
       let rpcUrl = runtime.getSetting(`ETHEREUM_PROVIDER_${chainName.toUpperCase()}`);
@@ -227,6 +229,7 @@ const genChainsFromRuntime = (runtime: IAgentRuntime): Record<string, Chain> => 
 
       const chain = WalletProvider.genChainFromName(chainName, rpcUrl);
       chains[chainName] = chain;
+      elizaLogger.log(`Configured chain: ${chainName}`);
     } catch (error) {
       elizaLogger.error(`Error configuring chain ${chainName}:`, error);
     }

--- a/src/providers/wallet.ts
+++ b/src/providers/wallet.ts
@@ -204,15 +204,16 @@ const genChainsFromRuntime = (runtime: IAgentRuntime): Record<string, Chain> => 
   // Get chains from settings - ONLY use configured chains
   const configuredChains = (runtime?.character?.settings?.chains?.evm as SupportedChain[]) || [];
 
-  // If no chains are configured, return empty object
+  // If no chains are configured, default to mainnet and base
+  const chainsToUse = configuredChains.length > 0 ? configuredChains : ['mainnet', 'base'];
+  
   if (configuredChains.length === 0) {
-    elizaLogger.warn('No EVM chains configured in settings');
-    return {};
+    elizaLogger.warn('No EVM chains configured in settings, defaulting to mainnet and base');
   }
 
   const chains: Record<string, Chain> = {};
 
-  for (const chainName of configuredChains) {
+  for (const chainName of chainsToUse) {
     try {
       // Try to get RPC URL from settings using different formats
       let rpcUrl = runtime.getSetting(`ETHEREUM_PROVIDER_${chainName.toUpperCase()}`);


### PR DESCRIPTION
## Description
This PR fixes an issue where the EVM plugin was attempting to check balances for all chains in the viem library instead of respecting only the chains configured in runtime settings.

Fixes https://github.com/elizaos-plugins/plugin-evm/issues/10

## Problem
When users configured specific chains like:
```javascript
settings: {
  chains: {
    evm: ['sepolia'],
  },
}
```

The plugin would still attempt to connect to and check balances for hundreds of other chains (mainnet, polygon, arbitrum, base, optimism, linea, berachainTestnet, etc.), causing unnecessary API calls and errors.

## Solution
- Removed the old default chains behavior that was automatically adding 6 chains (mainnet, polygon, arbitrum, base, optimism, linea)
- Changed WalletProvider to initialize with an empty chains object instead of spreading all viem chains
- Modified genChainsFromRuntime to only process chains explicitly listed in settings
- **Added mainnet and base as default fallback chains when no chains are configured**
- Added appropriate logging for debugging

## Changes
- Initialize `WalletProvider.chains` as empty object instead of `{ ...viemChains }`
- Remove the old default chains array that included 6 chains
- Only configure chains that are explicitly listed in `runtime.character.settings.chains.evm`
- **Default to mainnet and base when no chains are configured**
- Add warning when using default chains
- Add info log for each successfully configured chain

## Behavior
- **With configuration**: If chains are configured in settings, only those chains will be used
- **Without configuration**: If no chains are configured, defaults to mainnet and base
- **Clear logging**: Warns when using default chains vs configured chains

## Testing
After this change:
- The plugin will only attempt to connect to chains explicitly configured in settings
- If no chains are configured, it will default to mainnet and base only
- This prevents unnecessary API calls and errors for unconfigured chains

Fixes the issue reported where the plugin was trying to connect to chains like berachainTestnet despite only sepolia being configured.